### PR TITLE
Added option to disable parameter encoding in Authorization header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,41 @@
-.idea/
+# PLATFORM
+# ========
+# All exclusions that are specific to the NPM, GIT, IDE and Operating Systems.
+
+# - Do not allow installed node modules to be committed. Doing `npm install -d` will bring them in root or other places.
+node_modules
+
+# - Do not commit any log file from anywhere
+*.log
+*.log.*
+
+# - Prevent addition of OS specific file explorer files
+Thumbs.db
+.DS_Store
+
+# Prevent IDE stuff
+.idea
+.vscode
+
+# PROJECT
+# =======
+# Configuration pertaining to project specific repository structure.
+
+# - Prevent Sublime text IDE files from being commited to repository
+*.sublime-*
+
+# - Allow sublime text project file to be commited in the development directory.
+!/develop/*.sublime-project
+
+# - Prevent CI output files from being Added
+/out/
+
+# - Prevent diff backups from SourceTree from showing as commit.
+*.BACKUP.*
+*.BASE.*
+*.LOCAL.*
+*.REMOTE.*
+*.orig
+
+# - Prevent unit test coverage reports from being committed to the repository
+.coverage

--- a/index.js
+++ b/index.js
@@ -289,12 +289,13 @@ OAuth.setProperties(OAuth, // utility functions
         }
         ,
         /** Construct the value of the Authorization header for an HTTP request. */
-        getAuthorizationHeader: function getAuthorizationHeader(realm, parameters) {
+        getAuthorizationHeader: function getAuthorizationHeader(realm, parameters, disableParamsEncoding) {
             var header = 'OAuth ',
                 headerParams = [];
 
             if (realm && realm.trim()) {
-                headerParams.push(['realm', '"'+OAuth.percentEncode(realm)+'"'].join('='));
+                !disableParamsEncoding && (realm = OAuth.percentEncode(realm));
+                headerParams.push(`realm="${realm}"`);
             }
 
             var list = OAuth.getParameterList(parameters);
@@ -310,10 +311,16 @@ OAuth.setProperties(OAuth, // utility functions
                     value = value.toString().trim();
                 }
 
+                if (!disableParamsEncoding) {
+                    name = OAuth.percentEncode(name);
+                    value = OAuth.percentEncode(value);
+                }
+
                 if (name.indexOf('oauth_') == 0) {
-                    headerParams.push([OAuth.percentEncode(name), '"'+OAuth.percentEncode(value)+'"'].join('='));
+                    headerParams.push(`${name}="${value}"`);
                 }
             }
+
             return header + headerParams.join(',');
         }
         ,


### PR DESCRIPTION
`getAuthorizationHeader(realm, params, disableParamsEncoding)` function now takes an optional third argument (boolean) allowing to disable parameter encoding in Authorization header. If not provided, it will encode the parameters by default according to [RFC](https://tools.ietf.org/html/rfc5849).